### PR TITLE
Show PR's author

### DIFF
--- a/gql.go
+++ b/gql.go
@@ -41,6 +41,9 @@ const queryFmt = `{
 							name
 						}
 					}
+					author {
+						login
+					}
 				}
 			}
 		}
@@ -63,6 +66,9 @@ type PullRequest struct {
 			Name string `json:"name,omitempty"`
 		} `json:"nodes,omitempty"`
 	} `json:"labels,omitempty"`
+	Author struct {
+		Login string `json:"login,omitempty"`
+	} `json:"author,omitempty"`
 }
 
 func (pr PullRequest) LabelNames() []string {

--- a/main.go
+++ b/main.go
@@ -79,13 +79,15 @@ func main() {
 }
 
 func printPRs(title string, prs []PullRequest) {
-	if len(prs) != 0 {
-		fmt.Printf("%s:\n", strings.Title(title))
-		for _, pr := range prs {
-			fmt.Printf(" - %s (#%d)\n", pr.Title, pr.Number)
-		}
-		fmt.Println()
+	if len(prs) == 0 {
+		return
 	}
+
+	fmt.Printf("%s:\n", strings.Title(title))
+	for _, pr := range prs {
+		fmt.Printf(" - %s (#%d) [%s]\n", pr.Title, pr.Number, pr.Author.Login)
+	}
+	fmt.Println()
 }
 
 func pullRequestDesc(no int, all []PullRequest) (PullRequest, error) {


### PR DESCRIPTION
This PR will add the feature which shows PR's author.

Example:
```
$ prlog -repo gobuffalo/buffalo -to c6dd77a5 -from 5b2647fb
Other:
 - Fix test --force-migrations flag bug (#1812) [ypjama]
 - Add --json flag to buffalo version command (#1810) [rgo3]
 - Add "-timeout" option to "test" command (#1809) [laynemcnish]
 - Cleaning up old assets (#1785) [paganotoni]
 - Append URL and Query String parameter dupplicates (#1778) [Max-Pol]
 - Add ResourceName to RouteInfo struct (#1798) [alexisvisco]
 - Magic Numbers => HTTP Status Codes (#1802) [laynemcnish]
 - Changing plural to be singular on the modules variable (#1786) [paganotoni]
 - Update README.md (#1804) [shubhabanerjeewin8]
 - merge v0.14.11 in (#1808) [markbates]
 - merge v0.14.10 into development (#1775) [markbates]
 - update pop and other deps (#1774) [markbates]
 - (v0.15.0) Drop `dep` support fixes #1545 (#1759) [markbates]
 - Fix buffalo fix command (#1763) [stanislas-m]
 - could not find a template engine for plush error fixes #1757 (#1758) [markbates]
```